### PR TITLE
add multibyte public version support (zcash support)

### DIFF
--- a/lib/coinkey.js
+++ b/lib/coinkey.js
@@ -40,7 +40,8 @@ Object.defineProperty(CoinKey.prototype, 'privateWif', {
 
 Object.defineProperty(CoinKey.prototype, 'publicAddress', {
   get: function () {
-    return cs.encode(this.pubKeyHash, this.versions.public)
+    var bufVersion = util.bufferizeVersion(this.versions.public)
+    return cs.encode(this.pubKeyHash, bufVersion)
   }
 })
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -24,28 +24,16 @@ function normalizeVersions (versions) {
 }
 
 function bufferizeVersion (version) {
-  if (typeof version !== 'string' && typeof version !== 'number')
-    throw new Error('invalid version type.')
-
-  if (typeof version === 'string') {
-    return hexStringToBuffer(version)
-  } else if (typeof version === 'number') {
-    // expects BE uint
-    return beUIntToBuffer(version)
-  }
+  if (typeof version === 'string') return hexStringToBuffer(version)
+  if (typeof version === 'number') return beUIntToBuffer(version)
+  throw new Error('invalid version type.')
 }
 
-function isValidHexString (input) {
-  var re = /^(0x)?([\dA-Fa-f]{2})+$/g
-  return re.test(input)
-}
-
+// accepts hex string sequence with or without 0x prefix
 function hexStringToBuffer (input) {
-  if (!isValidHexString(input)) throw new Error('invalid hex string.')
-  // omit 0x for buffer
-  var re = /([\dA-Fa-f]{2})+$/g
-  const sanitizedInput = input.match(re)[0]
-  return new Buffer(sanitizedInput, 'hex')
+  var isValidRE = /^(0x)?([\dA-Fa-f]{2})+$/g
+  if (!isValidRE.test(input)) throw new Error('invalid hex string.')
+  return new Buffer(input.slice(input.slice(0, 2) === '0x' ? 2 : 0), 'hex')
 }
 
 function beUIntToBuffer (num) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -23,8 +23,18 @@ function normalizeVersions (versions) {
   else return null
 }
 
+function bufferizeVersion (version) {
+  var length
+  if (version === 0 || version === 1) length = 1
+  else if (version > 1) length = Math.ceil((Math.log(version) / Math.log(2)) / 8)
+  var buf = new Buffer(length)
+  buf.writeUIntBE(version, 0, length)
+  return buf
+}
+
 module.exports = {
   clone: clone,
   isArrayish: isArrayish,
-  normalizeVersions: normalizeVersions
+  normalizeVersions: normalizeVersions,
+  bufferizeVersion: bufferizeVersion
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -24,11 +24,37 @@ function normalizeVersions (versions) {
 }
 
 function bufferizeVersion (version) {
+  if (typeof version !== 'string' && typeof version !== 'number')
+    throw new Error('invalid version type.')
+
+  if (typeof version === 'string') {
+    return hexStringToBuffer(version)
+  } else if (typeof version === 'number') {
+    // expects BE uint
+    return beUIntToBuffer(version)
+  }
+}
+
+function isValidHexString (input) {
+  var re = /^(0x)?([\dA-Fa-f]{2})+$/g
+  return re.test(input)
+}
+
+function hexStringToBuffer (input) {
+  if (!isValidHexString(input)) throw new Error('invalid hex string.')
+  // omit 0x for buffer
+  var re = /([\dA-Fa-f]{2})+$/g
+  const sanitizedInput = input.match(re)[0]
+  return new Buffer(sanitizedInput, 'hex')
+}
+
+function beUIntToBuffer (num) {
   var length
-  if (version === 0 || version === 1) length = 1
-  else if (version > 1) length = Math.ceil((Math.log(version) / Math.log(2)) / 8)
+  if (num === 0) length = 1
+  else if (num > 0) length = Math.ceil((Math.log(num + 1) / Math.log(2)) / 8)
   var buf = new Buffer(length)
-  buf.writeUIntBE(version, 0, length)
+  buf.writeUIntBE(num, 0, length)
+
   return buf
 }
 

--- a/test/coinkey.test.js
+++ b/test/coinkey.test.js
@@ -83,14 +83,18 @@ describe('CoinKey', function () {
   describe('+ fromWif()', function () {
     fixtures.valid.forEach(function (f) {
       it('should return a new CoinKey ' + f.description, function () {
-        var ck = CoinKey.fromWif(f.privateWif)
+        // check if cointype is one where priv - pub is 0x80
+        // else version is expected to be explicitly passed
+        var standardCoin = f.versions.private - f.versions.public === 0x80
+
+        var ck = standardCoin ? CoinKey.fromWif(f.privateWif) : CoinKey.fromWif(f.privateWif, f.versions)
         assert.equal(ck.compressed, false)
         assert.equal(ck.versions.private, f.versions.private)
         assert.equal(ck.versions.public, f.versions.public)
         assert.equal(ck.privateKey.toString('hex'), f.privateKey)
         assert.equal(ck.publicAddress, f.publicAddress)
 
-        var ckCompressed = CoinKey.fromWif(f.privateWifCompressed)
+        var ckCompressed = standardCoin ? CoinKey.fromWif(f.privateWifCompressed) : CoinKey.fromWif(f.privateWifCompressed, f.versions)
         assert.equal(ckCompressed.compressed, true)
         assert.equal(ckCompressed.versions.private, f.versions.private)
         assert.equal(ckCompressed.versions.public, f.versions.public)

--- a/test/fixtures/coinkey.json
+++ b/test/fixtures/coinkey.json
@@ -52,6 +52,15 @@
       "publicAddress": "1337DopLwk7EWq3t513xdARgJ3Ey3MpC1jaWMk",
       "publicAddressCompressed": "1337Dy5vh54RZXHryrc3py9JxSvfo6P55JPWLn",
       "versions": {"private": 128, "public": "0x000f1111"},
+      "description": "0xmultibytetestcoin"
+    },
+    {
+      "privateKey": "1184cd2cdd640ca42cfc3a091c51d549b2f016d454b2774019c2b2d2e08529fd",
+      "privateWif": "5Hx15HFGyep2CfPxsJKe2fXJsCVn5DEiyoeGGF6JZjGbTRnqfiD",
+      "privateWifCompressed": "KwomKti1X3tYJUUMb1TGSM2mrZk1wb1aHisUNHCQXTZq5auC2qc3",
+      "publicAddress": "1337DopLwk7EWq3t513xdARgJ3Ey3MpC1jaWMk",
+      "publicAddressCompressed": "1337Dy5vh54RZXHryrc3py9JxSvfo6P55JPWLn",
+      "versions": {"private": 128, "public": "000f1111"},
       "description": "multibytetestcoin"
     }
   ]

--- a/test/fixtures/coinkey.json
+++ b/test/fixtures/coinkey.json
@@ -44,6 +44,15 @@
       "publicAddressCompressed": "t1YcvNCjWHAJ2pZWpAtejLTPXj4bAoVja3b",
       "versions": {"private": 128, "public": 7352},
       "description": "zcash"
+    },
+    {
+      "privateKey": "1184cd2cdd640ca42cfc3a091c51d549b2f016d454b2774019c2b2d2e08529fd",
+      "privateWif": "5Hx15HFGyep2CfPxsJKe2fXJsCVn5DEiyoeGGF6JZjGbTRnqfiD",
+      "privateWifCompressed": "KwomKti1X3tYJUUMb1TGSM2mrZk1wb1aHisUNHCQXTZq5auC2qc3",
+      "publicAddress": "1337DopLwk7EWq3t513xdARgJ3Ey3MpC1jaWMk",
+      "publicAddressCompressed": "1337Dy5vh54RZXHryrc3py9JxSvfo6P55JPWLn",
+      "versions": {"private": 128, "public": "0x000f1111"},
+      "description": "multibytetestcoin"
     }
   ]
 }

--- a/test/fixtures/coinkey.json
+++ b/test/fixtures/coinkey.json
@@ -35,6 +35,15 @@
       "publicAddressCompressed": "NBKgZWpMEDbzkTiRWHABRASXCdo8zWM8qC",
       "versions": {"private": 180, "public": 52},
       "description": "namecoin"
+    },
+    {
+      "privateKey": "1184cd2cdd640ca42cfc3a091c51d549b2f016d454b2774019c2b2d2e08529fd",
+      "privateWif": "5Hx15HFGyep2CfPxsJKe2fXJsCVn5DEiyoeGGF6JZjGbTRnqfiD",
+      "privateWifCompressed": "KwomKti1X3tYJUUMb1TGSM2mrZk1wb1aHisUNHCQXTZq5auC2qc3",
+      "publicAddress": "t1PMLcsnKEU43uhxiy5w6g3hpyL2HqtM3E2",
+      "publicAddressCompressed": "t1YcvNCjWHAJ2pZWpAtejLTPXj4bAoVja3b",
+      "versions": {"private": 128, "public": 7352},
+      "description": "zcash"
     }
   ]
 }


### PR DESCRIPTION
- adds support for coins, such as zcash, that use two or more bytes for
versioning of public addresses. This was done by converting all versions
passed as Buffers to coinstring, which the library insists on for
multibyte support.
- added zcash into test cases, required adding a conditional whereby
versions are passed into `fromWif` in the case the coin doesn't follow
the previous convention of priv - pub = 0x80. Can be easily done by also
leveraging coininfo.

Should result in all coins currently listed on coininfo being supported, except for Decred, which uses multibytes for the private key. Had an implementation for that too, but in general it seems that private keys are not intended to be supported with Decred for whatever reason.